### PR TITLE
기본 검색기능 구현 완성(제목만 검색가능), 헤더의 금융누르면 다시 전체 게시물 리스트 페이지로 이동

### DIFF
--- a/src/main/java/project/blobus/Backend/youth/finance/FinanceControllerTest.java
+++ b/src/main/java/project/blobus/Backend/youth/finance/FinanceControllerTest.java
@@ -20,11 +20,12 @@ public class FinanceControllerTest {
     // 페이징된 정책게시물 가져오기
     @GetMapping("/paged-policies")
     public Page<FinanceDTOTest> getPagedPolicies(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "0") int page,     // 페이지 번호
+            @RequestParam(defaultValue = "10") int size,    // 페이지 크기
+            @RequestParam(defaultValue = "") String keyword // 검색어 (기본값: 빈 문자열)
     ) {
-        Pageable pageable = PageRequest.of(page, size);
-        return financeServiceTest.getPagedPolicies(pageable);
+        Pageable pageable = PageRequest.of(page , size);                 // 페이징 객체 생성
+        return financeServiceTest.getPagedPolicies(keyword, pageable);  // 서비스 호출
     }
 
     // 모든 정책 가져오기

--- a/src/main/java/project/blobus/Backend/youth/finance/FinanceRepositoryTest.java
+++ b/src/main/java/project/blobus/Backend/youth/finance/FinanceRepositoryTest.java
@@ -9,4 +9,7 @@ import org.springframework.stereotype.Repository;
 public interface FinanceRepositoryTest extends JpaRepository<FinanceEntityTest, Integer> {
     // 필요한 경우 추가 메서드 정의 가능
     Page<FinanceEntityTest> findAll(Pageable pageable);
+
+    // 제목(title)에서 검색
+    Page<FinanceEntityTest> findByTitleContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/project/blobus/Backend/youth/finance/FinanceServiceTest.java
+++ b/src/main/java/project/blobus/Backend/youth/finance/FinanceServiceTest.java
@@ -17,9 +17,18 @@ public class FinanceServiceTest {
     }
 
     // 페이징된 정책 목록 가져오기
-    public Page<FinanceDTOTest> getPagedPolicies(Pageable pageable) {
-        return financeRepositoryTest.findAll(pageable)
-                .map(FinanceDTOTest::new); // Page<Entity> -> Page<DTO>로 변환
+    public Page<FinanceDTOTest> getPagedPolicies(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            // 검색어가 없으면 전체 데이터를 페이징 처리
+            return financeRepositoryTest.findAll(pageable)
+                    .map(FinanceDTOTest::new);
+        }
+        // 검색어가 있으면 제목에서 검색
+        return financeRepositoryTest.findByTitleContaining(keyword, pageable)
+                .map(FinanceDTOTest::new);
+
+//        return financeRepositoryTest.findAll(pageable)
+//                .map(FinanceDTOTest::new); // Page<Entity> -> Page<DTO>로 변환
     }
 
     // 모든 정책 가져오기

--- a/src/test/java/project/blobus/Backend/respository/FinanceRepositoryTestTest.java
+++ b/src/test/java/project/blobus/Backend/respository/FinanceRepositoryTestTest.java
@@ -28,7 +28,7 @@ public class FinanceRepositoryTestTest {
 
         // 더미 데이터 생성
         FinanceEntityTest policy = new FinanceEntityTest();
-        policy.setTitle("청년 주택 지원 정책4");
+        policy.setTitle("청년 우리는 내일도 희망희망");
         policy.setOverview("청년을 위한 주택 지원 정책4");
         policy.setApplicationPeriodStart(startDate);
         policy.setApplicationPeriodEnd(endDate);

--- a/src/test/java/project/blobus/Backend/service/FinanceServiceTestTest.java
+++ b/src/test/java/project/blobus/Backend/service/FinanceServiceTestTest.java
@@ -1,0 +1,32 @@
+//package project.blobus.Backend.service;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageRequest;
+//import org.springframework.data.domain.Pageable;
+//import project.blobus.Backend.youth.finance.FinanceDTOTest;
+//import project.blobus.Backend.youth.finance.FinanceServiceTest;
+//
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//
+//@SpringBootTest
+//public class FinanceServiceTestTest {
+//
+//    @Autowired
+//    private FinanceServiceTest financeServiceTest;
+//
+//    @Test
+//    public void testSearchPagedPolicies() {
+//        Pageable pageable = PageRequest.of(0, 10);
+//        Page<FinanceDTOTest> result = financeServiceTest.searchPagedPolicies("청년", pageable);
+//
+//        assertNotNull(result);
+//        assertTrue(result.getContent().size() <= 10); // 최대 10개씩 가져오기
+//        result.getContent().forEach(policy -> {
+//            assertTrue(policy.getTitle().contains("청년") || policy.getOverview().contains("청년"));
+//        });
+//    }
+//}


### PR DESCRIPTION
제목과 같음
이제 TODO로
- 검색 필터 적용시키기